### PR TITLE
Fix web implementation on Firefox and Safari

### DIFF
--- a/lib/src/pointer_lock_drag_area.dart
+++ b/lib/src/pointer_lock_drag_area.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';

--- a/lib/src/pointer_lock_web.dart
+++ b/lib/src/pointer_lock_web.dart
@@ -56,8 +56,10 @@ class PointerLockWeb extends PointerLockPlatform {
 
   @override
   Future<void> ensureInitialized() async {
-    _isInitialized = true;
-    _GlobalPointerHandlers.initialize();
+    if (!_isInitialized) {
+      _isInitialized = true;
+      _GlobalPointerHandlers.initialize();
+    }
   }
 
   @override


### PR DESCRIPTION
This PR adds support for Firefox and Safari.

In my testing, Firefox would not honor pointer move and pointer up subscriptions that were registered on a pointer down event. My solution here is to register pointer move and pointer up subscriptions in `ensureInitialized()` so that they last for the lifetime of the application, and then use Dart streams to temporarily hook into them when needed.

I don't have a Mac, so I developed this on Firefox and asked someone to test Safari on my behalf. Both appear to work fine, though Safari's banner is especially intrusive in that it pushes the page content down and resizes the viewport. I don't think there's a way around this, though please let me know if you're aware of anything.